### PR TITLE
fix(SF-1065): Remove padding from interpolated braces in the HTML templates

### DIFF
--- a/src/pager/index.html
+++ b/src/pager/index.html
@@ -1,7 +1,7 @@
-<gb-link class="gb-pager { gb-disabled: $paging.backDisabled }" on-click="{ $paging.prevPage }" _consumes="paging">
-  <span if="{ $paging.showLabels }">{ $paging.labels.prev }</span>
+<gb-link class="gb-pager {gb-disabled: $paging.backDisabled}" on-click="{$paging.prevPage}" _consumes="paging">
+  <span if="{$paging.showLabels}">{$paging.labels.prev}</span>
 </gb-link>
 <yield/>
-<gb-link class="gb-pager { gb-disabled: $paging.forwardDisabled }" on-click="{ $paging.nextPage }" _consumes="paging">
-  <span if="{ $paging.showLabels }">{ $paging.labels.next }</span>
+<gb-link class="gb-pager {gb-disabled: $paging.forwardDisabled}" on-click="{$paging.nextPage}" _consumes="paging">
+  <span if="{$paging.showLabels}">{$paging.labels.next}</span>
 </gb-link>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -1,7 +1,7 @@
-<ul class="gb-pages { gb-low-overflow: $paging.lowOverflow, gb-high-overflow: $paging.highOverflow }">
-  <li each="{ page in $paging.range }">
-    <gb-link class="gb-pages__page { gb-selected: $paging.current === page }" on-click="{ $paging.switchPage(page) }" page="{ page }">
-      <yield>{ props.page }</yield>
+<ul class="gb-pages {gb-low-overflow: $paging.lowOverflow, gb-high-overflow: $paging.highOverflow}">
+  <li each="{page in $paging.range}">
+    <gb-link class="gb-pages__page {gb-selected: $paging.current === page}" on-click="{$paging.switchPage(page)}" page="{page}">
+      <yield>{props.page}</yield>
     </gb-link>
   </li>
 </ul>

--- a/src/terminal-pager/index.html
+++ b/src/terminal-pager/index.html
@@ -1,7 +1,7 @@
-<gb-link class="gb-terminal-pager { gb-disabled: $paging.backDisabled }" on-click="{ $paging.firstPage }" _consumes="paging">
-  <span if="{ $paging.showLabels }">{ $paging.numericLabels ? $paging.first : $paging.labels.first }</span>
+<gb-link class="gb-terminal-pager {gb-disabled: $paging.backDisabled}" on-click="{$paging.firstPage}" _consumes="paging">
+  <span if="{$paging.showLabels}">{$paging.numericLabels ? $paging.first : $paging.labels.first}</span>
 </gb-link>
 <yield/>
-<gb-link class="gb-terminal-pager { gb-disabled: $paging.forwardDisabled }" on-click="{ $paging.lastPage }" _consumes="paging">
-  <span if="{ $paging.showLabels }">{ $paging.numericLabels ? $paging.last : $paging.labels.last }</span>
+<gb-link class="gb-terminal-pager {gb-disabled: $paging.forwardDisabled}" on-click="{$paging.lastPage}" _consumes="paging">
+  <span if="{$paging.showLabels}">{$paging.numericLabels ? $paging.last : $paging.labels.last}</span>
 </gb-link>


### PR DESCRIPTION
This fixes potential syntax errors coming from Riot.